### PR TITLE
feat: use bun-types

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -28,6 +28,10 @@
       "type": "build"
     },
     {
+      "name": "bun-types",
+      "type": "build"
+    },
+    {
       "name": "eslint-config-prettier",
       "type": "build"
     },
@@ -90,6 +94,10 @@
     {
       "name": "typescript",
       "type": "build"
+    },
+    {
+      "name": "bun-types",
+      "type": "peer"
     },
     {
       "name": "debug",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -4,6 +4,7 @@ const project = new OpsBRTypeScriptProject({
   defaultReleaseBranch: "main",
   deps: ["debug", "eslint-import-resolver-typescript"],
   devDeps: ["@opsbr/projen-typescript", "@types/debug"],
+  peerDeps: ["bun-types"],
   workflowPackageCache: true,
   releaseToNpm: true,
 });

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# replace this
+# eslint-import-resolver-typescript-bun
+
+This plugin simply adds workarounds to [eslint-import-resolver-typescript](https://www.npmjs.com/package/eslint-import-resolver-typescript) when resolving [Bun](https://bun.sh/)'s modules.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
+    "bun-types": "^0.6.12",
     "eslint": "^8",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-node": "^0.3.7",
@@ -47,6 +48,9 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "bun-types": "^0.6.12"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import debug from "debug";
 import { resolve as resolveTs } from "eslint-import-resolver-typescript";
 
@@ -5,10 +6,31 @@ const IMPORTER_NAME = "eslint-import-resolver-typescript-bun";
 
 const log = debug(IMPORTER_NAME);
 
+const findBunModules = () => {
+  const { found, path } = resolveTs("bun-types", "bun-types");
+  if (!found || !path) {
+    log("bun-types not found.");
+    return undefined;
+  }
+  // TODO: Better way to inspect .d.ts file.
+  const bunTypesDefinition = readFileSync(path, "utf-8");
+  const bunModules = new Set(
+    bunTypesDefinition
+      .split("\n")
+      // Find `declare module "bun..." {`
+      .filter((line) => line.includes('declare module "bun'))
+      // Extract `bun...` parts only
+      .map((line) => line.split('"')[1])
+  );
+  log("found bun modules:", bunModules);
+  return bunModules;
+};
+const bunModules = findBunModules();
+
 export const interfaceVersion = 2;
 
 export const resolve: typeof resolveTs = function (source, file, config) {
-  if (source.startsWith("bun:")) {
+  if (bunModules?.has(source)) {
     log("matched bun modules:", source);
     return { found: true, path: null };
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,7 +8,9 @@ test.each([
   { source: "fs", found: true, path: null },
   { source: "node:fs", found: true, path: null },
   { source: "not_found", found: false, path: undefined },
+  { source: "bun", found: true, path: null },
   { source: "bun:test", found: true, path: null },
+  { source: "bun:not_found", found: false, path: undefined },
 ])(
   "resolve $source => found: $found, path: $path",
   ({ source, found, path }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,6 +1465,11 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
+bun-types@^0.6.12:
+  version "0.6.12"
+  resolved "https://registry.yarnpkg.com/bun-types/-/bun-types-0.6.12.tgz#a2bdc7f2dc5e94f7e8f87f309c7c186956d28473"
+  integrity sha512-cICej22OR6uFNWMRgjKZR7X5w8WEsbM0lXhzftwCNvdsBDKNgLqLas5G2K0PuxLIxrUg859pP1i+FrngiotV1Q==
+
 bundle-name@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"


### PR DESCRIPTION
To check only valid Bun modules, this commit uses `bun-types`.

`bun-types` should be installed by the consumer because it's peerDependency.
